### PR TITLE
remove non-inverted "flicker" at page load of autoChange sites

### DIFF
--- a/js/iEye.js
+++ b/js/iEye.js
@@ -5,6 +5,7 @@
 // @description  Invert any page color by pressing ctrl+q, auto invert any page by adding domain in the autoChange array
 // @author       Jason de Belle
 // @match        *://*/*
+// @run-at document-start
 // @grant        none
 // ==/UserScript==
 

--- a/js/iEye.js
+++ b/js/iEye.js
@@ -5,7 +5,7 @@
 // @description  Invert any page color by pressing ctrl+q, auto invert any page by adding domain in the autoChange array
 // @author       Jason de Belle
 // @match        *://*/*
-// @run-at document-start
+// @run-at       document-start
 // @grant        none
 // ==/UserScript==
 


### PR DESCRIPTION
I've noticed that for sites included in the "autoChange" list, at page load there's a temporary flicker of the original (non-inverted) color scheme before this script is applied.  I added a Tampermonkey header, run-at (https://tampermonkey.net/documentation.php#_run_at), to direct the script to be loaded sooner, ensuring that the page gets loaded in inverted mode from th start.  Thanks.